### PR TITLE
Only install uninstalled packages from texlive.packages file

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -76,8 +76,10 @@ tlmgr update --self
 # install user-provided-packages
 if [ -f "$BUILD_DIR/texlive.packages" ]; then
     build-step "Installing custom packages..."
+    sort -u "$BUILD_DIR/texlive.packages" > "$TEXLIVE_CACHE/texlive.packages.sorted"
+    tlmgr info --only-installed --data name | sort > "$TEXLIVE_CACHE/texlive.packages.installed"
     # shellcheck disable=SC2046
-    tlmgr install $(cat "$BUILD_DIR/texlive.packages")
+    tlmgr install $(comm -23 "$TEXLIVE_CACHE/texlive.packages.sorted" "$TEXLIVE_CACHE/texlive.packages.installed")
 fi
 
 build-step "Updating installed packages..."


### PR DESCRIPTION
When a texlive.packages file is present, subsequent git pushes fail with the following error message:

```
remote: -----> TeX Live app detected
remote: -----> Setting up build cache...
remote: -----> Updating TeX Live...
remote: tlmgr: setting default package repository to http://mirror.ctan.org/systems/texlive/tlnet
remote: tlmgr: package repository http://mirrors.sorengard.com/ctan/systems/texlive/tlnet (verified)
remote: tlmgr: no self-updates for tlmgr available.
remote: -----> Installing custom packages...
remote: tlmgr install: package ngerman not present in repository.
remote: tlmgr: action install returned an error; continuing.
remote: tlmgr: package repository http://mirrors.concertpass.com/tex-archive/systems/texlive/tlnet (verified)
remote: tlmgr install: package already present: g-brief
remote: tlmgr: An error has occurred. See above messages. Exiting.
remote:  !     Push rejected, failed to compile TeX Live app.
remote: 
remote:  !     Push failed
```

Patch uses comm to get a list of only those packages, that are not yet installed. It will not remove packages if they are removed from the texlive.packages file.